### PR TITLE
Angel's Compatibility Fixes

### DIFF
--- a/compatibility-scripts/data-final-fixes/angels/angelspetrochem.lua
+++ b/compatibility-scripts/data-final-fixes/angels/angelspetrochem.lua
@@ -63,13 +63,24 @@ if mods["angelspetrochem"] then
     )
   end
 
-  -- Remove other unseful recipes and techs
-  data.raw.technology["resin-1"] = nil
-  data.raw.technology["resin-2"] = nil
-  data.raw.technology["resin-3"] = nil
+  -- Disable technologies 
+  local to_disable = {
+    "resin-1",
+    "resin-2",
+    "resin-3",
+    "angels-flare-stack",
+    "rubber"
+  }
+  
+  for _, research_name in pairs(to_disable) do
+    if data.raw.technology[research_name] then
+        data.raw.technology[research_name].enabled = false        
+    end
+  end
 
-  data.raw.technology["angel-flare-stack"] = nil
-  data.raw.technology["rubber"] = nil
+--Fix Technology Dead end
+krastorio.technologies.removeResearchUnitIngredient("rocket-fuel", "utility-science-pack")
+krastorio.technologies.addPrerequisite("rocket-fuel","production-science-pack")
 
   -- Change the air filters
   krastorio.technologies.addPrerequisite("kr-advanced-chemistry", "angels-nitrogen-processing-1")

--- a/compatibility-scripts/data-final-fixes/angels/angelsrefining.lua
+++ b/compatibility-scripts/data-final-fixes/angels/angelsrefining.lua
@@ -27,7 +27,7 @@ if mods["angelsrefining"] then
   for _, recipe_name in pairs(iron_recipes) do
     if data.raw.recipe[recipe_name] then
       data.raw.recipe[recipe_name].icons[1].icon = kr_items_icons_path .. "iron-plate.png"
-      data.raw.recipe[recipe_name].icons[2].icon_size = 32
+--         data.raw.recipe[recipe_name].icons[2].icon_size = 32 -- Doing this actually removed (or made the icon appear VERY small)
       data.raw.recipe[recipe_name].icon_size = 64
     end
   end

--- a/compatibility-scripts/data-final-fixes/angels/angelssmelting.lua
+++ b/compatibility-scripts/data-final-fixes/angels/angelssmelting.lua
@@ -21,7 +21,7 @@ if mods["angelssmelting"] then
     type = "recipe",
     name = "enriched-iron-smelting",
     icons = {
-      { icon = "__angelssmelting__/graphics/icons/ingot-iron.png" },
+      { icon = "__angelssmelting__/graphics/icons/ingot-iron.png", icon_size = 64 },
       { icon = enriched_iron.icon, icon_size = enriched_iron.icon_size, scale = 0.20, shift = { -8, -8 } },
     },
     category = "blast-smelting",
@@ -41,7 +41,7 @@ if mods["angelssmelting"] then
     type = "recipe",
     name = "enriched-copper-smelting",
     icons = {
-      { icon = "__angelssmelting__/graphics/icons/ingot-copper.png" },
+      { icon = "__angelssmelting__/graphics/icons/ingot-copper.png", icon_size = 64},
       { icon = enriched_copper.icon, icon_size = enriched_copper.icon_size, scale = 0.20, shift = { -8, -8 } },
     },
     category = "blast-smelting",
@@ -61,7 +61,7 @@ if mods["angelssmelting"] then
     type = "recipe",
     name = "enriched-iron-processing",
     icons = {
-      { icon = "__angelssmelting__/graphics/icons/processed-iron.png" },
+      { icon = "__angelssmelting__/graphics/icons/processed-iron.png", icon_size = 64 },
       { icon = enriched_iron.icon, icon_size = enriched_iron.icon_size, scale = 0.20, shift = { -8, -8 } },
     },
     category = "blast-smelting",
@@ -81,7 +81,7 @@ if mods["angelssmelting"] then
     type = "recipe",
     name = "enriched-copper-processing",
     icons = {
-      { icon = "__angelssmelting__/graphics/icons/processed-copper.png" },
+      { icon = "__angelssmelting__/graphics/icons/processed-copper.png", icon_size = 64 },
       { icon = enriched_copper.icon, icon_size = enriched_copper.icon_size, scale = 0.20, shift = { -8, -8 } },
     },
     category = "blast-smelting",
@@ -117,7 +117,7 @@ if mods["angelssmelting"] then
   -- Icons
 
   -- Coppers
-  local iron_recipes = {
+  local copper_recipes = {
     "angelsore3-crushed-smelting",
     "angels-copper-pebbles-smelting",
     "angels-copper-nugget-smelting",
@@ -126,10 +126,10 @@ if mods["angelssmelting"] then
     "angels-roll-copper-converting",
   }
 
-  for _, recipe_name in pairs(iron_recipes) do
+  for _, recipe_name in pairs(copper_recipes) do
     if data.raw.recipe[recipe_name] then
       data.raw.recipe[recipe_name].icons[1].icon = kr_items_icons_path .. "copper-plate.png"
-      data.raw.recipe[recipe_name].icons[2].icon_size = 32
+--         data.raw.recipe[recipe_name].icons[2].icon_size = 32 -- Doing this actually removed (or made the icon appear VERY small)
       data.raw.recipe[recipe_name].icon_size = 64
     end
   end
@@ -146,15 +146,16 @@ if mods["angelssmelting"] then
 
   -- Irons
   local iron_recipes = {
-    "steel-plate",
+    "steel-plate", -- Doesn't have an icons[2]
     "angels-plate-steel",
     "angels-roll-steel-converting",
   }
 
   for _, recipe_name in pairs(iron_recipes) do
     if data.raw.recipe[recipe_name] then
+      print(recipe_name)
       data.raw.recipe[recipe_name].icons[1].icon = kr_items_icons_path .. "steel-plate.png"
-      data.raw.recipe[recipe_name].icons[2].icon_size = 32
+--         data.raw.recipe[recipe_name].icons[2].icon_size = 32 -- Doing this actually removed (or made the icon appear VERY small)
       data.raw.recipe[recipe_name].icon_size = 64
     end
   end


### PR DESCRIPTION
This manages to get the game past loading and fixes a couple issues I noticed in the past such as a cyclical research problem, as well as icons in enriched processing recipes.

I also apologize for how the commits look in this, I was trying to be lazy and just copy my edits to the files on GitHub, but that wound up making 3 separate commits to PR. They are all included (in theory, but this may look weird potentially)

Testing:
- [x] Loaded to main menu
- [x] Research appears from first glance achievable
- [x] Small icons in the top left of many metal processing are now visible
- [x] Iron Ingots are no longer 2x larger than the square for Enriched -> Iron Ingot
- [ ] Play Testing will be performed later, but this would be far simpler to test in a public build since these were crashing at start up anyway.
