### PR TITLE
from the wind -> from wind

### DIFF
--- a/locale/en/Krastorio2.cfg
+++ b/locale/en/Krastorio2.cfg
@@ -185,7 +185,7 @@ kr-stabilizer-charging-station=Charges matter stabilization cells.
 kr-steel-pipe=A pipe that supports greater pressure.
 kr-steel-pipe-to-ground=An underground pipe that supports greater pressure.
 kr-tesla-coil=Recharges equipment grids that have an [item=energy-absorber] Energy absorber. Two towers may not be placed too close together!
-kr-wind-turbine=Produces a small amount of energy from the wind.
+kr-wind-turbine=Produces a small amount of energy from wind.
 
 [entity-status]
 kr-not-enough-input=Not enough power [img=info]


### PR DESCRIPTION
The definite article "the" isn't necessary in this context, as we're referring to wind as a general source of energy.

I have no idea why this bugged me, but it did. Please merge.