### PR TITLE
Do not override main menu background unless necessary

### DIFF
--- a/lib/public/data-stages/main-menu-backgrounds-util.lua
+++ b/lib/public/data-stages/main-menu-backgrounds-util.lua
@@ -15,7 +15,6 @@ function krastorio.backgrounds_utils.getBackgroundPath(name)
   if krastorio.backgrounds[name] then
     return krastorio.backgrounds[name]
   end
-  return "__core__/graphics/background-image.jpg"
 end
 
 return krastorio.backgrounds_utils

--- a/prototypes/vanilla-changes/optional/change-background.lua
+++ b/prototypes/vanilla-changes/optional/change-background.lua
@@ -1,7 +1,6 @@
 local backgrounds_util = require(kr_public_lib .. "main-menu-backgrounds-util")
 
 -- Add possible backgrounds
-backgrounds_util.addBackgroundImage("Factorio", "__core__/graphics/background-image.jpg")
 backgrounds_util.addBackgroundImage("Krastorio Legacy", kr_backgrounds_icons_path .. "krastorio-legacy.jpg")
 backgrounds_util.addBackgroundImage("Krastorio 2", kr_backgrounds_icons_path .. "krastorio-2.jpg")
 backgrounds_util.addBackgroundImage("Krastorio CyberSkull", kr_backgrounds_icons_path .. "krastorio-cyberskull.jpg")
@@ -16,11 +15,10 @@ backgrounds_util.addBackgroundImage("Factorio Alternative 4", kr_backgrounds_ico
 -- Choose the background depending on the setting
 local path_name = krastorio.general.getSafeSettingValue("kr-main-menu-background")
 if path_name then
-  data.raw["utility-constants"]["default"].main_menu_background_image_location =
-    backgrounds_util.getBackgroundPath(path_name)
-else
-  data.raw["utility-constants"]["default"].main_menu_background_image_location =
-    "__core__/graphics/background-image.jpg"
+  local path = backgrounds_util.getBackgroundPath(path_name)
+  if path then
+    data.raw["utility-constants"]["default"].main_menu_background_image_location = path
+  end
 end
 
 -- Remove base Factorio menu simulations (leave modded in)


### PR DESCRIPTION
I'm using a mod that provides custom main menu backgrounds, but currently Krastorio2 always overrides the main menu background, no matter which option I choose.

I propose that if someone chooses "Factorio" in main menu background settings, Krastorio2 does not override the background path.