### PR TITLE
Improve Compatibility with AngelBob's

### DIFF
--- a/compatibility-scripts/data-final-fixes/angels/angelspetrochem.lua
+++ b/compatibility-scripts/data-final-fixes/angels/angelspetrochem.lua
@@ -23,8 +23,8 @@ if mods["angelspetrochem"] then
     ["gas-chlorine"] = "chlorine",
     ["gas-hydrogen-chlorine"] = "hydrogen-chlorine",
     ["gas-oxygen"] = "oxygen",
-    ["gas-nitrogen"] = "nitrogen",
-    ["gas-ammonia"] = "ammonia",
+    --["gas-nitrogen"] = "nitrogen", -- Angel's replaces over Bob's with gas-nitrogen; this breaks it back
+    --["gas-ammonia"] = "ammonia", -- Angel's replaces over Bob's with gas-ammonia; this breaks it back
     ["liquid-nitric-acid"] = "nitric-acid",
     ["liquid-heavy-water"] = "heavy-water",
 

--- a/compatibility-scripts/data-final-fixes/angels/angelsrefining.lua
+++ b/compatibility-scripts/data-final-fixes/angels/angelsrefining.lua
@@ -20,15 +20,35 @@ if mods["angelsrefining"] then
     "angels-iron-pebbles-smelting",
     "angels-iron-nugget-smelting",
     "iron-plate",
-    "angels-plate-iron",
-    "angels-roll-iron-converting",
   }
 
   for _, recipe_name in pairs(iron_recipes) do
     if data.raw.recipe[recipe_name] then
       data.raw.recipe[recipe_name].icons[1].icon = kr_items_icons_path .. "iron-plate.png"
-      --         data.raw.recipe[recipe_name].icons[2].icon_size = 32 -- Doing this actually removed (or made the icon appear VERY small)
-      data.raw.recipe[recipe_name].icon_size = 64
+      data.raw.recipe[recipe_name].icons[1].icon_size = 64 -- override the base sprite size
+      data.raw.recipe[recipe_name].icons[1].scale = 32/64
+      data.raw.recipe[recipe_name].icons[2].icon_size = 32 -- override the 'exponent' sprite size
+      data.raw.recipe[recipe_name].icons[2].scale = 32/64
+      data.raw.recipe[recipe_name].icon_size = 64 -- override the composite sprite size
+      data.raw.recipe[recipe_name].scale = 32/64
+    end
+  end
+
+  -- These recipes use different scaling than the others
+  local badly_scaled_recipes = {
+    "angels-plate-iron",
+    "angels-roll-iron-converting",
+  }
+  -- Implement relative custom scaling
+  for _, recipe_name in pairs(badly_scaled_recipes) do
+    if data.raw.recipe[recipe_name] then
+      data.raw.recipe[recipe_name].icons[1].icon = kr_items_icons_path .. "iron-plate.png"
+      data.raw.recipe[recipe_name].icons[1].icon_size = 64 -- override the base sprite size
+      -- double the scale, because the background is double the size
+      data.raw.recipe[recipe_name].icons[2].scale = data.raw.recipe[recipe_name].icons[2].scale * 2
+      -- double the offset, because the background is twice the size
+      data.raw.recipe[recipe_name].icons[2].shift[1] = data.raw.recipe[recipe_name].icons[2].shift[1] * 2
+      data.raw.recipe[recipe_name].icons[2].shift[2] = data.raw.recipe[recipe_name].icons[2].shift[2] * 2
     end
   end
 

--- a/compatibility-scripts/data-final-fixes/angels/angelssmelting.lua
+++ b/compatibility-scripts/data-final-fixes/angels/angelssmelting.lua
@@ -122,17 +122,38 @@ if mods["angelssmelting"] then
     "angels-copper-pebbles-smelting",
     "angels-copper-nugget-smelting",
     "copper-plate",
-    "angels-plate-copper",
-    "angels-roll-copper-converting",
   }
 
   for _, recipe_name in pairs(copper_recipes) do
     if data.raw.recipe[recipe_name] then
       data.raw.recipe[recipe_name].icons[1].icon = kr_items_icons_path .. "copper-plate.png"
-      --         data.raw.recipe[recipe_name].icons[2].icon_size = 32 -- Doing this actually removed (or made the icon appear VERY small)
-      data.raw.recipe[recipe_name].icon_size = 64
+      data.raw.recipe[recipe_name].icons[1].icon_size = 64 -- override the base sprite size
+      data.raw.recipe[recipe_name].icons[1].scale = 32/64
+      data.raw.recipe[recipe_name].icons[2].icon_size = 32
+      data.raw.recipe[recipe_name].icons[2].scale = 32/64
+      data.raw.recipe[recipe_name].icon_size = 64 -- override the composite sprite size
+      data.raw.recipe[recipe_name].scale = 32/64
     end
   end
+
+  -- These recipes use different scaling than the others
+  local badly_scaled_recipes = {
+    "angels-plate-copper",
+    "angels-roll-copper-converting",
+  }
+  -- Implement relative custom scaling
+  for _, recipe_name in pairs(badly_scaled_recipes) do
+    if data.raw.recipe[recipe_name] then
+      data.raw.recipe[recipe_name].icons[1].icon = kr_items_icons_path .. "copper-plate.png"
+      data.raw.recipe[recipe_name].icons[1].icon_size = 64 -- override the base sprite size
+      -- double the scale, because the background is double the size
+      data.raw.recipe[recipe_name].icons[2].scale = data.raw.recipe[recipe_name].icons[2].scale * 2
+      -- double the offset, because the background is twice the size
+      data.raw.recipe[recipe_name].icons[2].shift[1] = data.raw.recipe[recipe_name].icons[2].shift[1] * 2
+      data.raw.recipe[recipe_name].icons[2].shift[2] = data.raw.recipe[recipe_name].icons[2].shift[2] * 2
+    end
+  end
+
 
   data.raw.recipe["enriched-copper-plate"].icons = {
     { icon = kr_items_icons_path .. "copper-plate.png", icon_size = 64 },
@@ -146,10 +167,16 @@ if mods["angelssmelting"] then
 
   -- Irons
   local iron_recipes = {
-    "steel-plate", -- Doesn't have an icons[2]
     "angels-plate-steel",
     "angels-roll-steel-converting",
   }
+
+  -- Needs to be handled separately because it uses icon instead of icons
+  if data.raw.recipe["steel-plate"] then
+    print("steel-plate")
+    data.raw.recipe["steel-plate"].icon = kr_items_icons_path .. "steel-plate.png"
+    data.raw.recipe["steel-plate"].icon_size = 64
+  end
 
   for _, recipe_name in pairs(iron_recipes) do
     if data.raw.recipe[recipe_name] then


### PR DESCRIPTION
This PR makes it so that AngelBob's will load alongside Krastorio2 by making some updates to the existing compatibility patches. It also fixes the issues with sprite scaling, although it might be worth refactoring that code at some point. No balancing or playability, just "it loads." If I have time, I may continue trying to add compat for K2/AB through future PRs.