### PR TITLE
Fix miniloader description clobber

### DIFF
--- a/prototypes/vanilla-changes/mandatory/improve-inserters.lua
+++ b/prototypes/vanilla-changes/mandatory/improve-inserters.lua
@@ -1,17 +1,15 @@
 -- Enabling custom vectors and burner leech (if possible) on all inserters
 for _, inserter in pairs(data.raw.inserter) do
   inserter.allow_custom_vectors = true
-  if not string.find(inserter.name, "%-?miniloader%-inserter") then
-    if not mods["bobinserters"] then
-      if inserter.localized_description then
-        inserter.localised_description = {
-          "other.conservative-additional-inserter-description",
-          inserter.localised_description,
-          { "other.additional-inserter-description" },
-        }
-      else
-        inserter.localised_description = { "other.additional-inserter-description" }
-      end
+  if not string.find(inserter.name, "%-?miniloader%-inserter") and not mods["bobinserters"] then
+    if inserter.localized_description then
+      inserter.localised_description = {
+        "other.conservative-additional-inserter-description",
+        inserter.localised_description,
+        { "other.additional-inserter-description" },
+      }
+    else
+      inserter.localised_description = { "other.additional-inserter-description" }
     end
   end
   if inserter.energy_source and inserter.energy_source.type == "burner" then

--- a/prototypes/vanilla-changes/mandatory/improve-inserters.lua
+++ b/prototypes/vanilla-changes/mandatory/improve-inserters.lua
@@ -1,15 +1,17 @@
 -- Enabling custom vectors and burner leech (if possible) on all inserters
 for _, inserter in pairs(data.raw.inserter) do
   inserter.allow_custom_vectors = true
-  if not mods["bobinserters"] then
-    if inserter.localized_description then
-      inserter.localised_description = {
-        "other.conservative-additional-inserter-description",
-        inserter.localised_description,
-        { "other.additional-inserter-description" },
-      }
-    else
-      inserter.localised_description = { "other.additional-inserter-description" }
+  if not string.find(inserter.name, "%-?miniloader%-inserter") then
+    if not mods["bobinserters"] then
+      if inserter.localized_description then
+        inserter.localised_description = {
+          "other.conservative-additional-inserter-description",
+          inserter.localised_description,
+          { "other.additional-inserter-description" },
+        }
+      else
+        inserter.localised_description = { "other.additional-inserter-description" }
+      end
     end
   end
   if inserter.energy_source and inserter.energy_source.type == "burner" then


### PR DESCRIPTION
Fixes miniloader description (items/second listing for that loader) being clobbered by the "press [command] to change drop lanes" description that isn't relevant for loaders

Found while investigating a different miniloader mod interaction issue
(after this change, "krastorio2" no longer appears in the "mods affecting this entity" list when hovering over miniloaders, also reducing noise when debugging)