### PR TITLE
fix syntax in ja/Krastorio2.cfg

### DIFF
--- a/locale/ja/Krastorio2.cfg
+++ b/locale/ja/Krastorio2.cfg
@@ -307,7 +307,6 @@ biters-research-data=バイター研究データ
 blank-tech-card=空のテクノロジーカード
 charged-antimatter-fuel-cell=充填済み反物質燃料セル
 charged-matter-stabilizer=充填済みマター安定
-"
 chemical-tech-card=化学テクノロジーカード
 coke=コークス
 dolphin-gun=宇宙イルカ銃
@@ -522,7 +521,6 @@ kr-containers=中型と大型のコンテナを追加します。他のMODコン
 kr-damage-and-ammo=レーザータレットは弱体化され、弾薬のダメージは大きく、核兵器は放射線ダメージも与えます。(デフォルト：有効)
 kr-electric-poles-changes=電柱の電力供給範囲と接続距離を拡大します。 (デフォルト：有効)
 kr-finite-oil=油田と鉱水を有限かつ生産速度を一定にします
-"
 kr-fix-laser-artillery-turret=この「修正」は、レーザータレットのリロード音をオフにすることでの不具合回避を試みます。
 kr-impossible-more-than-difficult=[color=red]このモードはサポートされていません。バグを報告しないでください。修正されません。[/color]\n高コスト設定ですべてのレシピとテクノロジーの材料のコストを2倍にします。これは通常の高コスト設定とは異なります。[color=orange]焦点を絞った[/color]レシピやテクノロジーコストを上げる代わりに [color=orange]他のmodのレシピも含め[/color]すべてのレシピを2倍にするからです。ノーマル設定には影響しないはずですが、高コスト設定でプレイしない場合は、このオプションを有効にする理由はありません。(デフォルトでは無効)
 kr-infinite-technology=ゲーム内アイテムの特性を向上させるテクノロジーで、アップグレードレベルが5以上あるものはすべて、無限アップグレードを有効にします。(デフォルト：有効)


### PR DESCRIPTION
After upgrading from 1.3.20 to 1.3.21, the following error occurred when starting the game.


in `factorio-previous,log`
```
   4.247 Loading mod Rocket-Silo-Construction 1.3.4 (data-final-fixes.lua)
   4.288 Loading mod space-exploration-postprocess 0.6.26 (data-final-fixes.lua)
   4.680 Script @__space-exploration__/collision-mask-util-extended/data/collision-mask-util-extended.lua:111: Named collision layer [planet-tile] set to layer [layer-22]
   4.707 Loading mod Mining-Space-Industries-II 0.8.2 (data-final-fixes.lua)
   4.747 Error ModManager.cpp:1608: Mod"Krastorio2"の読み込みに失敗しました: Failed to load locale: __Krastorio2__/locale/ja/Krastorio2.cfgに値がありません: 311.
   4.748 Loading mod core 0.0.0 (data.lua)
   4.867 Checksum for core: 1576756157
   4.922 Error ModManager.cpp:1608: Error in assignID: recipe-category with name 'crafting' does not exist.
```

I looked at the relevant section and found that there was an unnecessary `"` in it, which I removed and the game started up fine in my environment.
This probably occurs when the language setting is set to Japanese.

I am not familiar with this file. Please close this PR if you make any misplaced corrections.
