### PR TITLE
Change icon overlay of solid-fuel recipes

### DIFF
--- a/prototypes/vanilla-changes/mandatory/icons-changes.lua
+++ b/prototypes/vanilla-changes/mandatory/icons-changes.lua
@@ -234,11 +234,15 @@ local rocket_fuel_icons = {
   { icon = light_oil_icon, icon_size = data.raw.fluid["light-oil"].icon_size or 64, scale = 0.26, shift = { 8, -8 } },
 }
 krastorio.icons.setRecipeIcons("rocket-fuel", rocket_fuel_icons)
-local solid_fuel_icons = {
-  { icon = "__base__/graphics/icons/solid-fuel.png", icon_size = 64 },
-  { icon = light_oil_icon, icon_size = data.raw.fluid["light-oil"].icon_size or 64, scale = 0.26, shift = { -8, -8 } },
-}
-krastorio.icons.setRecipeIcons("solid-fuel-from-light-oil", solid_fuel_icons)
+
+local fluids_for_solid_fuel = {"petroleum-gas", "light-oil", "heavy-oil"}
+for _, fluid in ipairs(fluids_for_solid_fuel) do
+  local icons = {
+    { icon = "__base__/graphics/icons/solid-fuel.png", icon_size = 64 },
+    { icon = kr_fluids_icons_path .. fluid .. ".png", icon_size = data.raw.fluid[fluid].icon_size or 64, scale = 0.26, shift = { -8, -8 } }
+  }
+  krastorio.icons.setRecipeIcons("solid-fuel-from-" .. fluid, icons)
+end
 
 krastorio.icons.setItemIcon("electronic-circuit", kr_items_icons_path .. "electronic-circuit.png", 64, 4)
 krastorio.icons.setItemIcon("advanced-circuit", kr_items_icons_path .. "advanced-circuit.png", 64, 4)

--- a/prototypes/vanilla-changes/mandatory/icons-changes.lua
+++ b/prototypes/vanilla-changes/mandatory/icons-changes.lua
@@ -234,6 +234,11 @@ local rocket_fuel_icons = {
   { icon = light_oil_icon, icon_size = data.raw.fluid["light-oil"].icon_size or 64, scale = 0.26, shift = { 8, -8 } },
 }
 krastorio.icons.setRecipeIcons("rocket-fuel", rocket_fuel_icons)
+local solid_fuel_icons = {
+  { icon = "__base__/graphics/icons/solid-fuel.png", icon_size = 64 },
+  { icon = light_oil_icon, icon_size = data.raw.fluid["light-oil"].icon_size or 64, scale = 0.26, shift = { -8, -8 } },
+}
+krastorio.icons.setRecipeIcons("solid-fuel-from-light-oil", solid_fuel_icons)
 
 krastorio.icons.setItemIcon("electronic-circuit", kr_items_icons_path .. "electronic-circuit.png", 64, 4)
 krastorio.icons.setItemIcon("advanced-circuit", kr_items_icons_path .. "advanced-circuit.png", 64, 4)


### PR DESCRIPTION
K2 has changed the color of light oil icon but it is not reflected to the solid fuel recipe.
This PR updates the recipe icon with K2's light oil icon overlay.

Before: current K2 implementation

<img width="181" alt="before" src="https://github.com/raiguard/Krastorio2/assets/10973/e3223000-5cb1-4642-a89e-4847763de3d1">

After: applying this patch

<img width="183" alt="after" src="https://github.com/raiguard/Krastorio2/assets/10973/eb08a2cb-3607-4d10-ad42-e909f578df35">
