### PR TITLE
Compatibility fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.3.24
 Date: ????
-  Changes:
   Bugfixes:
-    - Fixed being unable to load the game when using Industrial Revolution 2 and Bob's Adjustable Inserters #389
+    - Fixed being unable to load the game when using Industrial Revolution 2 and Bob's Adjustable Inserters. (#389)
 ---------------------------------------------------------------------------------------------------
 Version: 1.3.23
 Date: 2023-10-15

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 Version: 1.3.24
 Date: ????
   Changes:
+  Bugfixes:
+    - Fixed being unable to load the game when using Industrial Revolution 2 and Bob's Adjustable Inserters #389
 ---------------------------------------------------------------------------------------------------
 Version: 1.3.23
 Date: 2023-10-15

--- a/compatibility-scripts/data-final-fixes/IndustrialRevolution.lua
+++ b/compatibility-scripts/data-final-fixes/IndustrialRevolution.lua
@@ -532,7 +532,7 @@ if mods["IndustrialRevolution"] then
 
   -- -- Fast replecable group next upgrades
   -- Inserters
-  data.raw.inserter["long-handed-inserter"].fast_replaceable_group = "long-handed-inserter"
+  data.raw.inserter["long-handed-inserter"].fast_replaceable_group = data.raw.inserter["kr-superior-long-inserter"].fast_replaceable_group
   data.raw.inserter["long-handed-inserter"].next_upgrade = "kr-superior-long-inserter"
   data.raw.inserter["kr-superior-filter-inserter"].fast_replaceable_group = "filter-inserter"
 


### PR DESCRIPTION
Fixing startup crash. Bob's Adjustable Inserters changes the `fast_replaceable_group` of all inserters from `long-handed-inserter` to `inserter`.

Mod list:
- Krastorio 2
- Industrial Revolution 2
- Bob's Adjustable Inserters

![image](https://github.com/raiguard/Krastorio2/assets/59639/ca0e32e6-a510-4116-ab47-4534fb591da7)

https://github.com/modded-factorio/bobsmods/blob/bf2d70e5dc976952bad3a4d364db54bf7616768d/bobinserters/data-final-fixes.lua#L3

Reported on mod portal:
https://mods.factorio.com/mod/bobinserters/discussion/6457b3e968a981fa87949509
