### PR TITLE
Make air purifiers and flare stacks indicate possible ingredients

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 1.3.24
 Date: ????
   Bugfixes:
     - Fixed being unable to load the game when using Industrial Revolution 2 and Bob's Adjustable Inserters. (#389)
+    - Fixed that the air purifier and flare stack didn't show possible ingredients. (#403, #411)
 ---------------------------------------------------------------------------------------------------
 Version: 1.3.23
 Date: 2023-10-15

--- a/lib/public/data-stages/fluid-burner-util.lua
+++ b/lib/public/data-stages/fluid-burner-util.lua
@@ -160,7 +160,7 @@ function krastorio.fluid_burner_util.generateBurnFluidsRecipe(fluid_name)
         },
         energy_required = 2,
         enabled = false,
-        hidden = true,
+        hidden = false,
         hide_from_player_crafting = true,
         always_show_products = false,
         show_amount_in_title = false,

--- a/prototypes/recipes/air-purification.lua
+++ b/prototypes/recipes/air-purification.lua
@@ -8,7 +8,8 @@ return {
     icon_size = 64,
     energy_required = 480,
     enabled = false,
-    hidden = true,
+    hidden = false,
+    hide_from_player_crafting = true,
     ingredients = {
       { type = "item", name = "pollution-filter", amount = 1 },
     },

--- a/prototypes/recipes/air-purification.lua
+++ b/prototypes/recipes/air-purification.lua
@@ -27,7 +27,8 @@ return {
     icon_size = 64,
     energy_required = 600,
     enabled = false,
-    hidden = true,
+    hidden = false,
+    hide_from_player_crafting = true,
     ingredients = {
       { type = "item", name = "improved-pollution-filter", amount = 1 },
     },


### PR DESCRIPTION
Credit RedRafe's suggestion https://discord.com/channels/587417951335088129/587418590744018955/1190126230327021658

When the recipe properties include `hidden = false, hide_from_player_crafting = true`, the player's crafting menu will not show the recipes but the recipe UI for the appropriate buildings will show them. This change improves the UI of air purifiers and flare stacks using this feature.