### PR TITLE
Add compatibility for Better Victory Screen

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 Version: 1.3.24
 Date: ????
   Changes:
+  Compatibility:
+    - Added compatibility with Better Victory Screen. (#407)
 ---------------------------------------------------------------------------------------------------
 Version: 1.3.23
 Date: 2023-10-15

--- a/info.json
+++ b/info.json
@@ -28,7 +28,7 @@
     "(?) Tral_robot_tree_farm >= 1.2.5",
     "(?) vtk-armor-plating >= 0.8.0",
     "(?) WaterAsAResource >= 0.7.8",
-    "(?) better-victory-screen >= 0.2.6",
+    "(?) better-victory-screen >= 0.2.8",
     "! Annotorio >= 0.3.0",
     "! brave-new-world >= 3.2.1",
     "! Clowns-Nuclear >= 1.3.7",

--- a/info.json
+++ b/info.json
@@ -28,6 +28,7 @@
     "(?) Tral_robot_tree_farm >= 1.2.5",
     "(?) vtk-armor-plating >= 0.8.0",
     "(?) WaterAsAResource >= 0.7.8",
+    "(?) better-victory-screen >= 0.2.4",
     "! Annotorio >= 0.3.0",
     "! brave-new-world >= 3.2.1",
     "! Clowns-Nuclear >= 1.3.7",

--- a/info.json
+++ b/info.json
@@ -28,7 +28,7 @@
     "(?) Tral_robot_tree_farm >= 1.2.5",
     "(?) vtk-armor-plating >= 0.8.0",
     "(?) WaterAsAResource >= 0.7.8",
-    "(?) better-victory-screen >= 0.2.8",
+    "(?) better-victory-screen >= 0.2.10",
     "! Annotorio >= 0.3.0",
     "! brave-new-world >= 3.2.1",
     "! Clowns-Nuclear >= 1.3.7",

--- a/info.json
+++ b/info.json
@@ -28,7 +28,7 @@
     "(?) Tral_robot_tree_farm >= 1.2.5",
     "(?) vtk-armor-plating >= 0.8.0",
     "(?) WaterAsAResource >= 0.7.8",
-    "(?) better-victory-screen >= 0.2.4",
+    "(?) better-victory-screen >= 0.2.6",
     "! Annotorio >= 0.3.0",
     "! brave-new-world >= 3.2.1",
     "! Clowns-Nuclear >= 1.3.7",

--- a/locale/en/Krastorio2Compatibility.cfg
+++ b/locale/en/Krastorio2Compatibility.cfg
@@ -29,3 +29,12 @@ kr-matter-lead-processing=Lead conversion
 kr-matter-nickel-processing=Nickel conversion
 kr-matter-tellurium-processing=Tellurium conversion
 kr-matter-tin-processing=Tin conversion
+
+[bvs-categories]
+intergalactic-communication=Intergalactic Communication
+
+[bvs-stats]
+charging-intergalactic-transceiver=Transceiver charge time
+
+[bvs-stat-tooltip]
+charging-intergalactic-transceiver=Time taken from the moment it was built to fully charge Intergalactic Transceiver.

--- a/locale/en/Krastorio2Compatibility.cfg
+++ b/locale/en/Krastorio2Compatibility.cfg
@@ -38,3 +38,6 @@ charging-intergalactic-transceiver=Transceiver charge time
 
 [bvs-stat-tooltip]
 charging-intergalactic-transceiver=Time taken from the moment it was built to fully charge Intergalactic Transceiver.
+
+[gui-game-finished]
+victory=Intergalactic communication established!

--- a/scripts/freeplay.lua
+++ b/scripts/freeplay.lua
@@ -69,8 +69,10 @@ function freeplay.set_custom_intro()
 end
 
 function freeplay.disable_rocket_victory()
-  if remote.interfaces["silo_script"] then
-    remote.call("silo_script", "set_no_victory", true)
+  for _, interface in pairs{"silo_script", "better-victory-screen"} do
+    if remote.interfaces[interface] and remote.interfaces[interface]["set_no_victory"] then
+      remote.call(interface, "set_no_victory", true)
+    end
   end
 end
 

--- a/scripts/intergalactic-transceiver.lua
+++ b/scripts/intergalactic-transceiver.lua
@@ -373,12 +373,16 @@ end
 
 --- @param force_index uint
 function cutscene.win(force_index)
-  game.set_game_state({
-    game_finished = true,
-    player_won = true,
-    can_continue = true,
-    victorious_force = game.forces[force_index],
-  })
+  if remote.interfaces["better-victory-screen"] and remote.interfaces["better-victory-screen"]["trigger_victory"] then
+    remote.call("better-victory-screen", "trigger_victory", game.forces[force_index])
+  else
+    game.set_game_state({
+      game_finished = true,
+      player_won = true,
+      can_continue = true,
+      victorious_force = game.forces[force_index],
+    })
+  end
 end
 
 function cutscene.play_victory_sound(force_index)

--- a/scripts/intergalactic-transceiver.lua
+++ b/scripts/intergalactic-transceiver.lua
@@ -67,6 +67,7 @@ function intergalactic_transceiver.build(entity)
     status = "empty",
     tick_built = game.tick,
     tick_ready = nil,
+    charge_time = nil, -- Total time charged. Calculated during activation
   }
 end
 
@@ -584,21 +585,14 @@ intergalactic_transceiver.remote_interface = {
   ---@param winning_force LuaForce
   ---@param forces LuaForce[] list of forces that GUI will be show to
   ["better-victory-screen-statistics"] = function(winning_force, forces)
-    local statistics = { by_force = { } }
-    for _, force in pairs(forces) do
-      local data = global.intergalactic_transceiver.forces[force.index]
-      if not data or not data.charge_time then goto continue end
-      statistics.by_force = {
-        -- Only add information to winning force
-        [winning_force.name] = {
-          ["intergalactic-communication"] = { order = "a", stats = {
-            ["charging-intergalactic-transceiver"] = {value = data.charge_time, unit = "time"}
-          }}
-        }
-      }
-      ::continue::
-    end
-    return statistics
+    -- Only add the transceiver charge time to the winning force's victory screen
+    local data = global.intergalactic_transceiver.forces[winning_force.index]
+    if not data or not data.charge_time then return { } end
+    return { by_force = { [winning_force.name] = {
+        ["intergalactic-communication"] = { order = "aa", stats = {
+          ["charging-intergalactic-transceiver"] = {value = data.charge_time, unit = "time"}
+        }}
+    }}}
   end
 }
 

--- a/scripts/intergalactic-transceiver.lua
+++ b/scripts/intergalactic-transceiver.lua
@@ -365,7 +365,7 @@ function cutscene.replace_entity(force_index)
 
     on_tick_n.add(game.tick + 660, { handler = "it_cutscene", action = "unlock_logo", force_index = force_index })
 
-    if global.intergalactic_transceiver.is_victory and not (game.finished or global.finished[force_index]) then
+    if global.intergalactic_transceiver.is_victory and not (game.finished or global.finished) then
       on_tick_n.add(game.tick + 650, { handler = "it_cutscene", action = "win", force_index = force_index })
       on_tick_n.add(
         game.tick + 660,
@@ -382,7 +382,7 @@ end
 
 --- @param force_index uint
 function cutscene.win(force_index)
-  global.finished[force_index] = true
+  global.finished = true
 
   if remote.interfaces["better-victory-screen"] and remote.interfaces["better-victory-screen"]["trigger_victory"] then
     remote.call("better-victory-screen", "trigger_victory", game.forces[force_index])

--- a/scripts/intergalactic-transceiver.lua
+++ b/scripts/intergalactic-transceiver.lua
@@ -590,7 +590,7 @@ intergalactic_transceiver.remote_interface = {
     if not data or not data.charge_time then return { } end
     return { by_force = { [winning_force.name] = {
         ["intergalactic-communication"] = { order = "aa", stats = {
-          ["charging-intergalactic-transceiver"] = {value = data.charge_time, unit = "time"}
+          ["charging-intergalactic-transceiver"] = {value = data.charge_time, unit = "time", has_tooltip=true}
         }}
     }}}
   end

--- a/scripts/intergalactic-transceiver.lua
+++ b/scripts/intergalactic-transceiver.lua
@@ -385,7 +385,7 @@ function cutscene.win(force_index)
   global.finished = true
 
   if remote.interfaces["better-victory-screen"] and remote.interfaces["better-victory-screen"]["trigger_victory"] then
-    remote.call("better-victory-screen", "trigger_victory", game.forces[force_index])
+    remote.call("better-victory-screen", "trigger_victory", game.forces[force_index], true) -- Force it always
   else
     game.set_game_state({
       game_finished = true,

--- a/scripts/intergalactic-transceiver.lua
+++ b/scripts/intergalactic-transceiver.lua
@@ -360,15 +360,12 @@ function cutscene.replace_entity(force_index)
   entity_data.activating = false
 
   if new_entity and new_entity.valid then
-    local charge_time
-    if entity_data.tick_built and entity_data.tick_ready then
-      charge_time = entity_data.tick_ready - entity_data.tick_built
-    end
+    local charge_time = (entity_data.tick_ready and entity_data.tick_built) and (entity_data.tick_ready - entity_data.tick_built)
     global.intergalactic_transceiver.forces[force.index] = { entity = new_entity, charge_time = charge_time }
 
     on_tick_n.add(game.tick + 660, { handler = "it_cutscene", action = "unlock_logo", force_index = force_index })
 
-    if global.intergalactic_transceiver.is_victory and not game.finished then
+    if global.intergalactic_transceiver.is_victory and not (game.finished or global.finished[force_index]) then
       on_tick_n.add(game.tick + 650, { handler = "it_cutscene", action = "win", force_index = force_index })
       on_tick_n.add(
         game.tick + 660,
@@ -385,6 +382,8 @@ end
 
 --- @param force_index uint
 function cutscene.win(force_index)
+  global.finished[force_index] = true
+
   if remote.interfaces["better-victory-screen"] and remote.interfaces["better-victory-screen"]["trigger_victory"] then
     remote.call("better-victory-screen", "trigger_victory", game.forces[force_index])
   else

--- a/scripts/migrations.lua
+++ b/scripts/migrations.lua
@@ -43,6 +43,10 @@ function migrations.generic()
     inserter.refresh_gui(player)
     roboport.refresh_gui(player)
   end
+
+  ---Keep track of the forces who have finished the game
+  ---@type table<int, boolean> where the key is the force index
+  global.finished = global.finished or {}
 end
 
 --- @param filters EntityPrototypeFilter[]

--- a/scripts/migrations.lua
+++ b/scripts/migrations.lua
@@ -43,10 +43,6 @@ function migrations.generic()
     inserter.refresh_gui(player)
     roboport.refresh_gui(player)
   end
-
-  ---Keep track of the forces who have finished the game
-  ---@type table<int, boolean> where the key is the force index
-  global.finished = global.finished or {}
 end
 
 --- @param filters EntityPrototypeFilter[]


### PR DESCRIPTION
Add's compatibility for [Better Victory Screen](https://mods.factorio.com/mod/better-victory-screen). Doesn't add extra entries into the GUI to keep it simple. You have full control of what is shown and what is not shown (read [here](https://github.com/heinwessels/factorio-better-victory-screen/blob/main/mod-page/compatibility.md) on how to change it). 

I added only one new statistic to the victory screen, which I think is quite cool. 

I also changed the victory text, which I'm happy to revert if you're not comfortable with it. It won't overwrite the custom SE message because SE depends on K2.

![image](https://github.com/raiguard/Krastorio2/assets/39875036/ffbea340-0147-4bae-ae96-ce480480a591)
