### PR TITLE
Add “Advanced lab” to prerequisites of “Utility tech card”

### DIFF
--- a/prototypes/vanilla-changes/mandatory/technologies-changes.lua
+++ b/prototypes/vanilla-changes/mandatory/technologies-changes.lua
@@ -36,6 +36,7 @@ krastorio.technologies.addPrerequisite("production-science-pack", "kr-research-s
 krastorio.technologies.addPrerequisite("production-science-pack", "kr-advanced-lab")
 krastorio.technologies.addPrerequisite("production-science-pack", "uranium-processing")
 krastorio.technologies.addPrerequisite("utility-science-pack", "kr-research-server")
+krastorio.technologies.addPrerequisite("utility-science-pack", "kr-advanced-lab")
 krastorio.technologies.addPrerequisite("utility-science-pack", "rocket-fuel")
 krastorio.technologies.addPrerequisite(krastorio.optimization_tech_card_name, "kr-singularity-lab")
 


### PR DESCRIPTION
Since you can’t make use of the **Utility tech card** without the **Advanced lab**, it makes sense to have it as a prerequisite, just as was done for the **Production tech card**.