### PR TITLE
Add support for Constructron-Continued

### DIFF
--- a/compatibility-scripts/data-updates/constructron-continued.lua
+++ b/compatibility-scripts/data-updates/constructron-continued.lua
@@ -1,0 +1,7 @@
+if mods["Constructron-Continued"] then
+  data.raw["spider-vehicle"]["constructron"].equipment_grid = "kr-spidertron-equipment-grid"
+  constructron_se = data.raw["spider-vehicle"]["constructron-rocket-powered"]
+  if constructron_se then
+	constructron_se.equipment_grid = "kr-spidertron-equipment-grid"
+  end
+end

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -39,6 +39,8 @@ require(scripts_path .. "Pyanodon")
 -- Schall Uranium Processing
 require(scripts_path .. "SchallUranium")
 require(scripts_path .. "Tral-robot-tree-farm")
+-- Constructron Continued
+require(scripts_path .. "Constructron-Continued")
 ---------------------------------------------------------------------------
 -- -- -- OTHER
 ---------------------------------------------------------------------------


### PR DESCRIPTION
Constructron-Continued adds two spider vehicles for automated construction. They need the same vehicle grid as spidertrons.