### PR TITLE
Nuclear Overhaul compatibility

### DIFF
--- a/scripts/compatibility.lua
+++ b/scripts/compatibility.lua
@@ -36,6 +36,32 @@ function compatibility.schall_uranium()
   end
 end
 
+function compatibility.nuclear_fuel()
+  if script.active_mods["nuclear-overhaul"] then
+    remote.call("kr-radioactivity", "add_entity", "thorium-ore")
+    remote.call("kr-radioactivity", "add_item", "neptunium-237")
+    remote.call("kr-radioactivity", "add_item", "plutonium-238")
+    remote.call("kr-radioactivity", "add_item", "plutonium-239")
+    remote.call("kr-radioactivity", "add_item", "plutonium-fuel")
+    remote.call("kr-radioactivity", "add_item", "plutonium-mox")
+    remote.call("kr-radioactivity", "add_item", "protactinium-233")
+    remote.call("kr-radioactivity", "add_item", "protactinium-234")
+    remote.call("kr-radioactivity", "add_item", "thorium-232")
+    remote.call("kr-radioactivity", "add_item", "thorium-233")
+    remote.call("kr-radioactivity", "add_item", "thorium-fuel")
+    remote.call("kr-radioactivity", "add_item", "thorium-mox")
+    remote.call("kr-radioactivity", "add_item", "thorium-ore")
+    remote.call("kr-radioactivity", "add_item", "uranium-233")
+    remote.call("kr-radioactivity", "add_item", "uranium-234")
+    remote.call("kr-radioactivity", "add_item", "uranium-236")
+    remote.call("kr-radioactivity", "add_item", "uranium-237")
+    remote.call("kr-radioactivity", "add_item", "uranium-mox")
+    remote.call("kr-radioactivity", "add_item", "used-plutonium-mox")
+    remote.call("kr-radioactivity", "add_item", "used-thorium-mox")
+    remote.call("kr-radioactivity", "add_item", "used-uranium-mox")
+  end
+end
+
 function compatibility.should_build_pump()
   if game.entity_prototypes["kr-electric-offshore-pump"] then
     return true

--- a/scripts/compatibility.lua
+++ b/scripts/compatibility.lua
@@ -36,7 +36,7 @@ function compatibility.schall_uranium()
   end
 end
 
-function compatibility.nuclear_fuel()
+function compatibility.nuclear_overhaul()
   if script.active_mods["nuclear-overhaul"] then
     remote.call("kr-radioactivity", "add_entity", "thorium-ore")
     remote.call("kr-radioactivity", "add_item", "neptunium-237")


### PR DESCRIPTION
Wish to add radioactivity for the resource and items created by Nuclear Overhaul.
Nuclear Overhaul has K2 as a dependency, so no change to info.json.