### PR TITLE
 fix: support space platform built and mine entity

### DIFF
--- a/scripts/intergalactic-transceiver.lua
+++ b/scripts/intergalactic-transceiver.lua
@@ -47,7 +47,7 @@ local status_properties = {
 local min_charge_delta = 2.5e8 -- Requires charge rate of 15 GW
 local max_charge_delta = 2e9
 local max_energy = prototypes.entity["kr-intergalactic-transceiver"].electric_energy_source_prototype.buffer_capacity
-  - max_charge_delta
+    - max_charge_delta
 local energy_drain = 50e9
 
 --- @param transceiver_data IntergalacticTransceiverForceData
@@ -249,7 +249,7 @@ local function create_gui(player, entity)
         type = "flow",
         style_mods = { vertical_align = "center" },
         { type = "sprite", name = "status_icon", style = "flib_indicator" },
-        { type = "label", name = "status_label" },
+        { type = "label",  name = "status_label" },
       },
       {
         type = "frame",
@@ -535,6 +535,8 @@ intergalactic_transceiver.events = {
   [defines.events.script_raised_built] = on_entity_built,
   [defines.events.script_raised_destroy] = on_entity_destroyed,
   [defines.events.script_raised_revive] = on_entity_built,
+  [defines.events.on_space_platform_built_entity] = on_entity_built,
+  [defines.events.on_space_platform_mined_entity] = on_entity_destroyed,
 }
 
 intergalactic_transceiver.on_nth_tick = {

--- a/scripts/intergalactic-transceiver.lua
+++ b/scripts/intergalactic-transceiver.lua
@@ -47,7 +47,7 @@ local status_properties = {
 local min_charge_delta = 2.5e8 -- Requires charge rate of 15 GW
 local max_charge_delta = 2e9
 local max_energy = prototypes.entity["kr-intergalactic-transceiver"].electric_energy_source_prototype.buffer_capacity
-    - max_charge_delta
+  - max_charge_delta
 local energy_drain = 50e9
 
 --- @param transceiver_data IntergalacticTransceiverForceData
@@ -249,7 +249,7 @@ local function create_gui(player, entity)
         type = "flow",
         style_mods = { vertical_align = "center" },
         { type = "sprite", name = "status_icon", style = "flib_indicator" },
-        { type = "label",  name = "status_label" },
+        { type = "label", name = "status_label" },
       },
       {
         type = "frame",

--- a/scripts/loader-snapping.lua
+++ b/scripts/loader-snapping.lua
@@ -102,9 +102,9 @@ local function snap_direction(entity)
     belt_type = belt.ghost_type
   end
   if
-    belt_type == "transport-belt"
-    or belt_type == "underground-belt"
-    or math.abs(offset_direction - belt.direction) % 4 == 0
+      belt_type == "transport-belt"
+      or belt_type == "underground-belt"
+      or math.abs(offset_direction - belt.direction) % 4 == 0
   then
     flip_loader(entity)
   end
@@ -161,6 +161,7 @@ snap_loader.events = {
   [defines.events.on_robot_built_entity] = on_entity_built,
   [defines.events.script_raised_built] = on_entity_built,
   [defines.events.script_raised_revive] = on_entity_built,
+  [defines.events.on_space_platform_built_entity] = on_entity_built,
 }
 
 return snap_loader

--- a/scripts/loader-snapping.lua
+++ b/scripts/loader-snapping.lua
@@ -102,9 +102,9 @@ local function snap_direction(entity)
     belt_type = belt.ghost_type
   end
   if
-      belt_type == "transport-belt"
-      or belt_type == "underground-belt"
-      or math.abs(offset_direction - belt.direction) % 4 == 0
+    belt_type == "transport-belt"
+    or belt_type == "underground-belt"
+    or math.abs(offset_direction - belt.direction) % 4 == 0
   then
     flip_loader(entity)
   end

--- a/scripts/migrations.lua
+++ b/scripts/migrations.lua
@@ -11,7 +11,7 @@ local migrations = {}
 migrations.on_init = ensure_turret_force
 
 function migrations.on_configuration_changed(e)
-  if flib_migration.on_config_changed(e, migrations.version) then
+  if flib_migration.on_config_changed(e, migrations.versions) then
     ensure_turret_force()
   end
 end
@@ -62,17 +62,17 @@ migrations.versions = {
     end
     for _, surface in pairs(game.surfaces) do
       for _, entity in
-        pairs(surface.find_entities_filtered({
-          name = {
-            "kr-planetary-teleporter-turret",
-            "kr-planetary-teleporter-front-layer",
-            "kr-planetary-teleporter-collision-1",
-            "kr-planetary-teleporter-collision-2",
-            "kr-planetary-teleporter-collision-3",
-            "kr-tesla-coil-turret",
-            "kr-tesla-coil-collision",
-          },
-        }))
+      pairs(surface.find_entities_filtered({
+        name = {
+          "kr-planetary-teleporter-turret",
+          "kr-planetary-teleporter-front-layer",
+          "kr-planetary-teleporter-collision-1",
+          "kr-planetary-teleporter-collision-2",
+          "kr-planetary-teleporter-collision-3",
+          "kr-tesla-coil-turret",
+          "kr-tesla-coil-collision",
+        },
+      }))
       do
         if entity.valid and not valid_unit_numbers[entity.unit_number] then
           entity.destroy()

--- a/scripts/migrations.lua
+++ b/scripts/migrations.lua
@@ -62,17 +62,17 @@ migrations.versions = {
     end
     for _, surface in pairs(game.surfaces) do
       for _, entity in
-      pairs(surface.find_entities_filtered({
-        name = {
-          "kr-planetary-teleporter-turret",
-          "kr-planetary-teleporter-front-layer",
-          "kr-planetary-teleporter-collision-1",
-          "kr-planetary-teleporter-collision-2",
-          "kr-planetary-teleporter-collision-3",
-          "kr-tesla-coil-turret",
-          "kr-tesla-coil-collision",
-        },
-      }))
+        pairs(surface.find_entities_filtered({
+          name = {
+            "kr-planetary-teleporter-turret",
+            "kr-planetary-teleporter-front-layer",
+            "kr-planetary-teleporter-collision-1",
+            "kr-planetary-teleporter-collision-2",
+            "kr-planetary-teleporter-collision-3",
+            "kr-tesla-coil-turret",
+            "kr-tesla-coil-collision",
+          },
+        }))
       do
         if entity.valid and not valid_unit_numbers[entity.unit_number] then
           entity.destroy()

--- a/scripts/planetary-teleporter.lua
+++ b/scripts/planetary-teleporter.lua
@@ -17,9 +17,9 @@ local flib_table = require("__flib__.table")
 --- @field front_layer LuaEntity
 
 local collision_entity_offsets = {
-  { x = 0, y = 0 },
+  { x = 0,  y = 0 },
   { x = -2, y = 2 },
-  { x = 2, y = 2 },
+  { x = 2,  y = 2 },
 }
 
 --- @param base_entity LuaEntity
@@ -80,12 +80,12 @@ local function on_entity_built(e)
 
   -- Don't keep cloned internal entities.
   if
-    e.name == defines.events.on_entity_cloned
-    and (
-      entity_name == "kr-planetary-teleporter-front-layer"
-      or entity_name == "kr-planetary-teleporter-turret"
-      or string.find(entity_name, "kr-planetary-teleporter-collision", nil, true)
-    )
+      e.name == defines.events.on_entity_cloned
+      and (
+        entity_name == "kr-planetary-teleporter-front-layer"
+        or entity_name == "kr-planetary-teleporter-turret"
+        or string.find(entity_name, "kr-planetary-teleporter-collision", nil, true)
+      )
   then
     entity.destroy()
     return
@@ -226,6 +226,8 @@ planetary_teleporter.events = {
   [defines.events.script_raised_built] = on_entity_built,
   [defines.events.script_raised_destroy] = on_entity_destroyed,
   [defines.events.script_raised_revive] = on_entity_built,
+  [defines.events.on_space_platform_built_entity] = on_entity_built,
+  [defines.events.on_space_platform_mined_entity] = on_entity_destroyed,
 }
 
 return planetary_teleporter

--- a/scripts/planetary-teleporter.lua
+++ b/scripts/planetary-teleporter.lua
@@ -17,9 +17,9 @@ local flib_table = require("__flib__.table")
 --- @field front_layer LuaEntity
 
 local collision_entity_offsets = {
-  { x = 0,  y = 0 },
+  { x = 0, y = 0 },
   { x = -2, y = 2 },
-  { x = 2,  y = 2 },
+  { x = 2, y = 2 },
 }
 
 --- @param base_entity LuaEntity
@@ -80,12 +80,12 @@ local function on_entity_built(e)
 
   -- Don't keep cloned internal entities.
   if
-      e.name == defines.events.on_entity_cloned
-      and (
-        entity_name == "kr-planetary-teleporter-front-layer"
-        or entity_name == "kr-planetary-teleporter-turret"
-        or string.find(entity_name, "kr-planetary-teleporter-collision", nil, true)
-      )
+    e.name == defines.events.on_entity_cloned
+    and (
+      entity_name == "kr-planetary-teleporter-front-layer"
+      or entity_name == "kr-planetary-teleporter-turret"
+      or string.find(entity_name, "kr-planetary-teleporter-collision", nil, true)
+    )
   then
     entity.destroy()
     return

--- a/scripts/shelter.lua
+++ b/scripts/shelter.lua
@@ -154,6 +154,8 @@ shelter.events = {
   [defines.events.script_raised_built] = on_entity_built,
   [defines.events.script_raised_destroy] = on_entity_destroyed,
   [defines.events.script_raised_revive] = on_entity_built,
+  [defines.events.on_space_platform_built_entity] = on_entity_built,
+  [defines.events.on_space_platform_mined_entity] = on_entity_destroyed,
 }
 
 shelter.on_nth_tick = {

--- a/scripts/tesla-coil.lua
+++ b/scripts/tesla-coil.lua
@@ -19,8 +19,8 @@ local function on_entity_built(e)
 
   -- Internal entities should not be cloned
   if
-      e.name == defines.events.on_entity_cloned
-      and (entity_name == "kr-tesla-coil-turret" or entity_name == "kr-tesla-coil-collision")
+    e.name == defines.events.on_entity_cloned
+    and (entity_name == "kr-tesla-coil-turret" or entity_name == "kr-tesla-coil-collision")
   then
     entity.destroy()
     return

--- a/scripts/tesla-coil.lua
+++ b/scripts/tesla-coil.lua
@@ -19,8 +19,8 @@ local function on_entity_built(e)
 
   -- Internal entities should not be cloned
   if
-    e.name == defines.events.on_entity_cloned
-    and (entity_name == "kr-tesla-coil-turret" or entity_name == "kr-tesla-coil-collision")
+      e.name == defines.events.on_entity_cloned
+      and (entity_name == "kr-tesla-coil-turret" or entity_name == "kr-tesla-coil-collision")
   then
     entity.destroy()
     return
@@ -380,6 +380,8 @@ tesla_coil.events = {
   [defines.events.script_raised_built] = on_entity_built,
   [defines.events.script_raised_destroy] = on_entity_destroyed,
   [defines.events.script_raised_revive] = on_entity_built,
+  [defines.events.on_space_platform_built_entity] = on_entity_built,
+  [defines.events.on_space_platform_mined_entity] = on_entity_destroyed,
 }
 
 return tesla_coil

--- a/types.lua
+++ b/types.lua
@@ -1,7 +1,7 @@
 --- @meta
 
---- @alias EntityBuiltEvent EventData.on_built_entity|EventData.on_robot_built_entity|EventData.on_entity_cloned|EventData.script_raised_built|EventData.script_raised_revive
---- @alias EntityDestroyedEvent EventData.on_player_mined_entity|EventData.on_robot_mined_entity|EventData.on_entity_died|EventData.script_raised_destroy
+--- @alias EntityBuiltEvent EventData.on_built_entity|EventData.on_robot_built_entity|EventData.on_space_platform_built_entity|EventData.on_entity_cloned|EventData.script_raised_built|EventData.script_raised_revive
+--- @alias EntityDestroyedEvent EventData.on_player_mined_entity|EventData.on_robot_mined_entity|EventData.on_space_platform_mined_entity|EventData.on_entity_died|EventData.script_raised_destroy
 
 --- @alias PlayerIndex uint
 --- @alias UnitNumber uint


### PR DESCRIPTION
Fix calling events for entities being built and mined on space platforms.

on_built_events will still work if entity ghosts are considered but the actual creation is triggered by 'on_space_platform_built_entity'

Fix migrations variable typo
Fixes: #439 