### PR TITLE
Place K2 resources on nauvis

### DIFF
--- a/prototypes/updates/set-new-resource-autoplace.lua
+++ b/prototypes/updates/set-new-resource-autoplace.lua
@@ -15,3 +15,8 @@ for _, preset in pairs(data.raw["map-gen-presets"].default) do
     preset.basic_settings.autoplace_controls["rare-metals"] = preset.basic_settings.autoplace_controls[base_ore]
   end
 end
+
+for _, resource in ipairs({"imersite", "mineral-water", "rare-metals"}) do
+  data.raw.planet.nauvis.map_gen_settings.autoplace_controls[resource] = {}
+  data.raw.planet.nauvis.map_gen_settings.autoplace_settings.entity.settings[resource] = {}
+end


### PR DESCRIPTION
This adds the K2 resources on Nauvis. I used same approach for fixing this as in Ultracube, i.e. inspired by this commit

https://github.com/grandseiken/factorio-ultracube/commit/9e39fba6ffc4212406b53b485f5fd411f5c9f985

Before
![Screenshot From 2024-12-04 10-40-54](https://github.com/user-attachments/assets/285a3f96-e99b-4212-8f9e-730ac30377e0)

After
![Screenshot From 2024-12-04 10-38-32](https://github.com/user-attachments/assets/b11cd42c-32c6-4234-8acc-ce09fe96eeeb)
