### PR TITLE
Fix enforce used science packs

### DIFF
--- a/lib/private/data-stages/items.lua
+++ b/lib/private/data-stages/items.lua
@@ -18,23 +18,6 @@ function krastorio.items.getItem(item_name)
   return nil
 end
 
-function krastorio.items.getAllItemsOfType(item_type)
-  local exist = false
-  local items = {}
-  for _, _type in pairs(defines.prototypes.item) do
-    if _type == item_type then
-      exist = true
-      break
-    end
-  end
-  if exist then
-    for name, item in pairs(data.raw[item_type]) do
-      table.insert(items, item)
-    end
-  end
-  return items
-end
-
 function krastorio.items.getItemType(item_name)
   local item = krastorio.items.getItem(item_name)
   if item and item.type then

--- a/lib/private/data-stages/technologies.lua
+++ b/lib/private/data-stages/technologies.lua
@@ -1011,7 +1011,7 @@ end
 function krastorio.technologies.enforceUsedSciencePacksInPrerequisites()
   -- calculate existance of science pack technologies
   local science_techs = {}
-  for _, science_pack in pairs(krastorio.items.getAllItemsOfType("tool")) do
+  for _, science_pack in pairs(data.raw.tool) do
     local science_pack_tech = krastorio.technologies.getTechnologyFromName(science_pack.name)
       or krastorio.technologies.getTechnologyThatUnlockRecipe(science_pack.name)
     if science_pack_tech then


### PR DESCRIPTION
Hey! This PR is a bit questionable since we are moving away from the `krastorio` global variable entirely and this file is probably deprecated.

But, anyway, I was puzzled by why the recipes don't include the science packs as prerequisites and I realized that this code in `enforceUsedSciencePacksInPrerequisites()` was not working, due to `krastorio.items.getAllItemsOfType()` returning empty result. But this list of packs is available directly in `data.raw.tool` instead.

I suppose there are two alternatives:
* taking this method `enforceUsedSciencePacksInPrerequisites()` and breaking it out to a separate file along with the needed helper methods and operating on `data.raw` instead.
* log what this method actually ends up doing and then just including the relevant science packs directly in the technology definitions (which will be less hairy abstractions to deal with)

What do you think?

With this PR now I kind of have a *very* similar experience to 1.1 in early game play and by examining tech tree and factoriopedia side-by-side and I have not found any more discrepancies, so if having a fully testable/playable version on 2.0 is of any benefit for futher dev I think this set of PRs could help.

Before:
![Screenshot From 2024-12-05 19-19-29](https://github.com/user-attachments/assets/85e0936b-6fae-4eed-a8fd-12ec3af1db1b)

After:
![Screenshot From 2024-12-05 19-18-31](https://github.com/user-attachments/assets/660b0011-e3c2-44d6-acab-e0c268d633de)