### PR TITLE
Fixed tech card related stuff

### DIFF
--- a/prototypes/buildings/biusart-lab.lua
+++ b/prototypes/buildings/biusart-lab.lua
@@ -40,7 +40,6 @@ data:extend({
       "chemical-science-pack",
       "production-science-pack",
       "utility-science-pack",
-      kr_optimization_tech_card_name,
     },
     module_slots = 2,
     energy_source = {

--- a/prototypes/updates/base/recipes.lua
+++ b/prototypes/updates/base/recipes.lua
@@ -695,6 +695,7 @@ data.raw.recipe["automation-science-pack"] = {
     { type = "item", name = "automation-core", amount = 1 },
   },
   results = { { type = "item", name = "automation-science-pack", amount = 5 } },
+  allow_productivity = true,
 }
 
 data.raw.recipe["logistic-science-pack"] = {
@@ -708,6 +709,7 @@ data.raw.recipe["logistic-science-pack"] = {
     { type = "item", name = "iron-gear-wheel", amount = 5 },
   },
   results = { { type = "item", name = "logistic-science-pack", amount = 5 } },
+  allow_productivity = true,
 }
 
 data.raw.recipe["military-science-pack"] = {
@@ -721,6 +723,7 @@ data.raw.recipe["military-science-pack"] = {
     { type = "item", name = "electronic-components", amount = 5 },
   },
   results = { { type = "item", name = "military-science-pack", amount = 5 } },
+  allow_productivity = true,
 }
 
 data.raw.recipe["chemical-science-pack"] = {
@@ -736,11 +739,13 @@ data.raw.recipe["chemical-science-pack"] = {
     { type = "fluid", name = "sulfuric-acid", amount = 50 },
   },
   results = { { type = "item", name = "chemical-science-pack", amount = 5 } },
+  allow_productivity = true,
 }
 
 data.raw.recipe["production-science-pack"] = {
   type = "recipe",
   name = "production-science-pack",
+  category = "t2-tech-cards",
   enabled = false,
   energy_required = 20,
   ingredients = {
@@ -750,11 +755,13 @@ data.raw.recipe["production-science-pack"] = {
     { type = "item", name = "uranium-238", amount = 5 },
   },
   results = { { type = "item", name = "production-science-pack", amount = 5 } },
+  allow_productivity = true,
 }
 
 data.raw.recipe["utility-science-pack"] = {
   type = "recipe",
   name = "utility-science-pack",
+  category = "t2-tech-cards",
   enabled = false,
   energy_required = 20,
   ingredients = {
@@ -764,6 +771,7 @@ data.raw.recipe["utility-science-pack"] = {
     { type = "item", name = "low-density-structure", amount = 5 },
   },
   results = { { type = "item", name = "utility-science-pack", amount = 5 } },
+  allow_productivity = true,
 }
 
 -- TODO: Do we want the custom heavy/light oil icons?

--- a/prototypes/updates/base/technologies.lua
+++ b/prototypes/updates/base/technologies.lua
@@ -37,6 +37,7 @@ data_util.add_prerequisite("steam-power", "kr-automation-core")
 data_util.add_prerequisite("steel-axe", "kr-iron-pickaxe")
 data_util.add_prerequisite("stone-wall", "military")
 data_util.add_prerequisite("tank", "kr-fuel")
+data_util.add_prerequisite("utility-science-pack", "kr-advanced-lab")
 data_util.add_prerequisite("utility-science-pack", "kr-research-server")
 data_util.add_prerequisite("utility-science-pack", "rocket-fuel")
 


### PR DESCRIPTION
Restored things to how they were in 1.1.
- Optimization tech cards only go into Singularity labs not Advanced labs.
- Allowed Productivity on tech cards.
- Added `t2-tech-cards` category to Production and Utility tech cards so they can be crafted in - Research servers instead of Assembling machines.

Made Advanced lab a prerequisite of Utility tech card similar to the Production tech card.