### PR TITLE
Fixed technology icons

### DIFF
--- a/prototypes/technologies/basic-tech-card.lua
+++ b/prototypes/technologies/basic-tech-card.lua
@@ -130,14 +130,7 @@ data:extend({
   {
     type = "technology",
     name = "kr-iron-pickaxe",
-    icons = {
-      { icon = "__Krastorio2Assets__/technologies/iron-pickaxe.png", icon_size = 256 },
-      {
-        icon = "__core__/graphics/icons/technology/constants/constant-mining.png",
-        icon_size = 128,
-        shift = { 100, 100 },
-      },
-    },
+    icons = util.technology_icon_constant_mining("__Krastorio2Assets__/technologies/iron-pickaxe.png"),
     order = "b-c-a",
     unit = {
       time = 30,

--- a/prototypes/technologies/chemical-science-pack.lua
+++ b/prototypes/technologies/chemical-science-pack.lua
@@ -223,13 +223,7 @@ data:extend({
   {
     type = "technology",
     name = "kr-nuclear-reactor-equipment",
-    icons = {
-      {
-        icon = "__core__/graphics/icons/technology/constants/constant-equipment.png",
-        icon_size = 128,
-        shift = { 100, 100 },
-      },
-    },
+    icons = util.technology_icon_constant_equipment("__Krastorio2Assets__/technologies/nuclear-reactor-equipment.png"),
     upgrade = false,
     unit = {
       time = 60,
@@ -248,17 +242,7 @@ data:extend({
   {
     type = "technology",
     name = "kr-portable-generator-equipment",
-    icons = {
-      {
-        icon = "__Krastorio2Assets__/technologies/portable-generator-equipment.png",
-        icon_size = 256,
-      },
-      {
-        icon = "__core__/graphics/icons/technology/constants/constant-equipment.png",
-        icon_size = 128,
-        shift = { 100, 100 },
-      },
-    },
+    icons = util.technology_icon_constant_equipment("__Krastorio2Assets__/technologies/portable-generator-equipment.png"),
     upgrade = false,
     unit = {
       time = 60,

--- a/prototypes/technologies/matter-tech-card.lua
+++ b/prototypes/technologies/matter-tech-card.lua
@@ -3,17 +3,7 @@ data:extend({
     type = "technology",
     name = "kr-advanced-pickaxe",
     icon_size = 256,
-    icons = {
-      {
-        icon = "__Krastorio2Assets__/technologies/imersium-pickaxe.png",
-        icon_size = 256,
-      },
-      {
-        icon = "__core__/graphics/icons/technology/constants/constant-mining.png",
-        icon_size = 128,
-        shift = { 100, 100 },
-      },
-    },
+    icons = util.technology_icon_constant_mining("__Krastorio2Assets__/technologies/imersium-pickaxe.png"),
     unit = {
       time = 60,
       count = 200,

--- a/prototypes/technologies/singularity-tech-card.lua
+++ b/prototypes/technologies/singularity-tech-card.lua
@@ -52,17 +52,7 @@ data:extend({
   {
     type = "technology",
     name = "kr-antimatter-reactor-equipment",
-    icons = {
-      {
-        icon = "__Krastorio2Assets__/technologies/antimatter-reactor-equipment.png",
-        icon_size = 256,
-      },
-      {
-        icon = "__core__/graphics/icons/technology/constants/constant-equipment.png",
-        icon_size = 128,
-        shift = { 100, 100 },
-      },
-    },
+    icons = util.technology_icon_constant_equipment("__Krastorio2Assets__/technologies/antimatter-reactor-equipment.png"),
     upgrade = false,
     unit = {
       time = 45,

--- a/prototypes/technologies/utility-science-pack.lua
+++ b/prototypes/technologies/utility-science-pack.lua
@@ -2,17 +2,7 @@ data:extend({
   {
     type = "technology",
     name = "kr-advanced-additional-engine-equipment",
-    icons = {
-      {
-        icon = "__Krastorio2Assets__/technologies/advanced-additional-engine-equipment.png",
-        icon_size = 256,
-      },
-      {
-        icon = "__core__/graphics/icons/technology/constants/constant-equipment.png",
-        icon_size = 128,
-        shift = { 100, 100 },
-      },
-    },
+    icons = util.technology_icon_constant_equipment("__Krastorio2Assets__/technologies/advanced-additional-engine-equipment.png"),
     icon_size = 256,
     upgrade = false,
     unit = {

--- a/prototypes/updates/base/technologies.lua
+++ b/prototypes/updates/base/technologies.lua
@@ -121,6 +121,16 @@ data.raw.technology["steam-power"].unit = {
   },
 }
 
+data.raw.technology["steel-axe"].research_trigger = nil
+data.raw.technology["steel-axe"].unit = {
+  time = 30,
+  count = 50,
+  ingredients = {
+    { "basic-tech-card", 1 },
+    { "automation-science-pack", 1 },
+  },
+}
+
 data.raw.technology["artillery"].unit.count = 1000
 data.raw.technology["atomic-bomb"].unit.count = 1500
 data.raw.technology["automation-3"].unit.count = 350
@@ -172,6 +182,8 @@ data_util.set_icons(data.raw.technology["fission-reactor-equipment"], {
   { icon = "__Krastorio2Assets__/technologies/fission-reactor-equipment.png", icon_size = 256 },
   { icon = "__Krastorio2Assets__/technologies/overlays/equipment-overlay.png", icon_size = 256 },
 })
+
+data_util.set_icons(data.raw.technology["steel-axe"], util.technology_icon_constant_mining("__Krastorio2Assets__/technologies/steel-pickaxe.png"))
 
 data.raw.technology["personal-laser-defense-equipment"].localised_name = {
   "technology-name.kr-personal-laser-defense-mk1-equipment",


### PR DESCRIPTION
Fixed some technology icons.
Also changed steel axe technology to be like it was in 1.1.
Here are some examples:

![tech before](https://github.com/user-attachments/assets/6358a6ce-e866-47a7-a471-073507cc43e5)
![tech after](https://github.com/user-attachments/assets/77965e71-b83e-4a9d-b11d-e0fc27d0a65c)
![reactor before](https://github.com/user-attachments/assets/2c442822-23f2-4c06-b4fc-6568c3b1eba3)
![reactor after](https://github.com/user-attachments/assets/f4c49677-5a49-46d7-9b88-d141f7518739)
![axe before](https://github.com/user-attachments/assets/526552a9-cdc1-4203-a356-d95ef9f902b4)
![axe after](https://github.com/user-attachments/assets/e5d4a01f-3ab5-4e0a-985d-2e95e54bf223)
