### PR TITLE
Removed concrete-dummy.png from reinforced plates

### DIFF
--- a/prototypes/tiles/reinforced-plates.lua
+++ b/prototypes/tiles/reinforced-plates.lua
@@ -381,25 +381,6 @@ data:extend({
     transition_overlay_layer_offset = 2, -- need to render border overlay on top of hazard-concrete
     decorative_removal_probability = 0.95,
     variants = {
-      main = {
-        {
-          picture = "__base__/graphics/terrain/concrete/concrete-dummy.png",
-          count = 1,
-          size = 1,
-        },
-        {
-          picture = "__base__/graphics/terrain/concrete/concrete-dummy.png",
-          count = 1,
-          size = 2,
-          probability = 0.39,
-        },
-        {
-          picture = "__base__/graphics/terrain/concrete/concrete-dummy.png",
-          count = 1,
-          size = 4,
-          probability = 1,
-        },
-      },
       transition = {
         overlay_layout = {
           inner_corner = {
@@ -485,25 +466,6 @@ data:extend({
     transition_overlay_layer_offset = 2, -- need to render border overlay on top of hazard-concrete
     decorative_removal_probability = 0.95,
     variants = {
-      main = {
-        {
-          picture = "__base__/graphics/terrain/concrete/concrete-dummy.png",
-          count = 1,
-          size = 1,
-        },
-        {
-          picture = "__base__/graphics/terrain/concrete/concrete-dummy.png",
-          count = 1,
-          size = 2,
-          probability = 0.39,
-        },
-        {
-          picture = "__base__/graphics/terrain/concrete/concrete-dummy.png",
-          count = 1,
-          size = 4,
-          probability = 1,
-        },
-      },
       transition = {
         overlay_layout = {
           inner_corner = {


### PR DESCRIPTION
\_\_base\_\_/graphics/terrain/concrete/concrete-dummy.png got removed in 2.0.33.
looks like it was just an empty image.
concrete looks the same as before.