### PR TITLE
Fixed Advanced lab alt-mode icons

### DIFF
--- a/prototypes/buildings/biusart-lab.lua
+++ b/prototypes/buildings/biusart-lab.lua
@@ -184,5 +184,15 @@ data:extend({
         },
       },
     },
+    icons_positioning = {
+        {
+            inventory_index = defines.inventory.lab_input,
+            shift = { 0, -0.3 },
+        },
+        {
+            inventory_index = defines.inventory.lab_modules,
+            shift = { 0, 0.9 },
+        },
+    },
   },
 })


### PR DESCRIPTION
Fixes #462 
![image](https://github.com/user-attachments/assets/47c35190-c477-4d0b-9acc-b4a42233c476)
