### PR TITLE
Fix scaling cost of technologies

### DIFF
--- a/prototypes/updates/base/technologies.lua
+++ b/prototypes/updates/base/technologies.lua
@@ -165,7 +165,7 @@ data.raw.technology["artillery-shell-range-1"].unit.count_formula = "L^2*3500"
 data.raw.technology["artillery-shell-speed-1"].max_level = 2
 data.raw.technology["artillery-shell-speed-1"].unit.count_formula = "L^2*3500"
 
-data.raw.technology["follower-robot-count-5"].unit.count_formula = "((L-6)^2)*5000"
+data.raw.technology["follower-robot-count-5"].unit.count_formula = "((L-4)^2)*5000"
 data.raw.technology["follower-robot-count-5"].max_level = nil
 
 data.raw.technology["laser-weapons-damage-7"].max_level = 10
@@ -312,7 +312,7 @@ data:extend({
     max_level = 8,
     unit = {
       time = 60,
-      count_formula = "((L-6)^2)*5000",
+      count_formula = "((L-5)^2)*5000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -345,7 +345,7 @@ data:extend({
     max_level = 10,
     unit = {
       time = 60,
-      count_formula = "((L-8)^2)*5000",
+      count_formula = "((L-5)^2)*5000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -377,7 +377,7 @@ data:extend({
     max_level = 8,
     unit = {
       time = 60,
-      count_formula = "((L-7)^2)*5000",
+      count_formula = "((L-4)^2)*5000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -408,7 +408,7 @@ data:extend({
     max_level = 10,
     unit = {
       time = 60,
-      count_formula = "((L-8)^2)*5000",
+      count_formula = "((L-4)^2)*5000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -441,7 +441,7 @@ data:extend({
     max_level = 15,
     unit = {
       time = 60,
-      count_formula = "((L-10)^2)*3000",
+      count_formula = "((L-6)^2)*3000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -476,7 +476,7 @@ data:extend({
     max_level = 18,
     unit = {
       time = 60,
-      count_formula = "((L-15)^2)*3000",
+      count_formula = "((L-6)^2)*3000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -512,7 +512,7 @@ data:extend({
     max_level = 15,
     unit = {
       time = 60,
-      count_formula = "((L-10)^2)*3000",
+      count_formula = "((L-6)^2)*3000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -547,7 +547,7 @@ data:extend({
     max_level = 18,
     unit = {
       time = 60,
-      count_formula = "((L-15)^2)*3000",
+      count_formula = "((L-6)^2)*3000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -583,7 +583,7 @@ data:extend({
     max_level = 15,
     unit = {
       time = 60,
-      count_formula = "((L-10)^2)*3000",
+      count_formula = "((L-6)^2)*3000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -616,7 +616,7 @@ data:extend({
     max_level = 18,
     unit = {
       time = 60,
-      count_formula = "((L-15)^2)*3000",
+      count_formula = "((L-6)^2)*3000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -649,7 +649,7 @@ data:extend({
     max_level = 15,
     unit = {
       time = 60,
-      count_formula = "((L-10)^2)*3000",
+      count_formula = "((L-6)^2)*3000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -680,7 +680,7 @@ data:extend({
     max_level = 18,
     unit = {
       time = 60,
-      count_formula = "((L-15)^2)*3000",
+      count_formula = "((L-6)^2)*3000",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -745,7 +745,7 @@ data:extend({
     max_level = 7,
     unit = {
       time = 60,
-      count_formula = "((L-4)^2)*3500",
+      count_formula = "((L-3)^2)*3500",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },
@@ -810,7 +810,7 @@ data:extend({
     max_level = 7,
     unit = {
       time = 60,
-      count_formula = "((L-4)^2)*3500",
+      count_formula = "((L-2)^2)*3500",
       ingredients = {
         { "production-science-pack", 1 },
         { "utility-science-pack", 1 },


### PR DESCRIPTION
Addressing issue #297 

* Fixed scaling of technologies when the required science would drop at every tier
* Fixed technologies that were scaling based on a higher level than the technology, follower-robot-count-7 should have previously been free. 

Example change for refined flammables

| Level | Old   | New    |
|-------|-------|--------|
|     7 |  3000 |   3000 |
|     8 | 12000 |  12000 |
|     9 | 27000 |  27000 |
|    10 | 48000 |  48000 |
|    11 |  3000 |  75000 |
|    12 | 12000 | 108000 |
|    13 | 27000 | 147000 |
|    14 | 48000 | 192000 |
|    15 | 75000 | 243000 |
|    16 |  3000 | 300000 |
|    17 | 12000 | 363000 |
|    18 | 27000 | 432000 |