### PR TITLE
Update exoskeleton recipes

### DIFF
--- a/prototypes/equipment/advanced-exoskeleton-equipment.lua
+++ b/prototypes/equipment/advanced-exoskeleton-equipment.lua
@@ -7,7 +7,7 @@ data:extend({
     ingredients = {
       { type = "item", name = "exoskeleton-equipment", amount = 1 },
       { type = "item", name = "low-density-structure", amount = 10 },
-      { type = "item", name = "advanced-circuit", amount = 10 },
+      { type = "item", name = "processing-unit", amount = 10 },
       { type = "item", name = "speed-module-2", amount = 10 },
     },
     results = { { type = "item", name = "advanced-exoskeleton-equipment", amount = 1 } },

--- a/prototypes/updates/base/recipes.lua
+++ b/prototypes/updates/base/recipes.lua
@@ -176,6 +176,12 @@ data_util.add_or_replace_ingredient(
 
 data_util.convert_ingredient("engine-unit", "steel-plate", "iron-plate")
 
+data.raw.recipe["exoskeleton-equipment"].ingredients = {
+  { type = "item", name = "electric-engine", amount = 10 },
+  { type = "item", name = "advanced-circuit", amount = 10 },
+  { type = "item", name = "steel-plate", amount = 10 },
+}
+
 data_util.add_or_replace_ingredient(
   "express-splitter",
   "iron-gear-wheel",

--- a/prototypes/updates/base/recipes.lua
+++ b/prototypes/updates/base/recipes.lua
@@ -177,7 +177,7 @@ data_util.add_or_replace_ingredient(
 data_util.convert_ingredient("engine-unit", "steel-plate", "iron-plate")
 
 data.raw.recipe["exoskeleton-equipment"].ingredients = {
-  { type = "item", name = "electric-engine", amount = 10 },
+  { type = "item", name = "electric-engine-unit", amount = 10 },
   { type = "item", name = "advanced-circuit", amount = 10 },
   { type = "item", name = "steel-plate", amount = 10 },
 }


### PR DESCRIPTION
Update exoskeleton 1 & 2 recipes to make exoskeleton 1 cheaper and match ingredient costs of exoskeleton 2 & 3 resolves #306 

(Changes are bolded and italicized)
exoskeleton 1:
30x electric engine, 10x processing unit, 20x steel plate ->
 _**10x**_ electric engine, 10x **_advanced circuit_**, **_10x_** steel plate

exoskeleton 2: 
1x exoskeleton 1, 10x low density structure, 10x advanced circuits, 10x speed module 2 -> 
1x exoskeleton 1, 10x low density structure, 10x **_processing unit_**, 10x speed module 2