### PR TITLE
Soft incompatibility with quality and space age

### DIFF
--- a/info.json
+++ b/info.json
@@ -30,8 +30,6 @@
     "(?) vtk-armor-plating >= 0.8.0",
     "(?) WaterAsAResource >= 0.7.8",
     "(?) better-victory-screen >= 0.2.10",
-    "! quality",
-    "! space-age",
     "! Annotorio",
     "! brave-new-world",
     "! Clowns-Nuclear",

--- a/settings-final-fixes.lua
+++ b/settings-final-fixes.lua
@@ -1,0 +1,31 @@
+do
+  local incompatible_with_space_age = mods["space-age"] and data.raw["bool-setting"]["kr-incompatible-with-space-age"].forced_value
+  local incompatible_with_quality   = mods["quality"  ] and data.raw["bool-setting"]["kr-incompatible-with-quality"  ].forced_value
+
+  if incompatible_with_space_age or incompatible_with_quality then
+    local message = "\n\n[space-age] [font=default-bold]Krastorio 2[/font] is not compatible with "
+
+    local incompatibilities = {}
+    if incompatible_with_space_age then
+      table.insert(incompatibilities, "[font=default-bold]Space Age[/font]")
+    end
+    if incompatible_with_quality then
+      table.insert(incompatibilities, "[font=default-bold]Quality[/font]")
+    end
+    message = message .. table.concat(incompatibilities, " nor ") .. ","
+    message = message .. " resolve the conflict by clicking the [font=default-bold][Manage mods][/font] button below.\n"
+    -- message = message .. " please click the [font=default-bold][Manage mods][/font] button to resolve it.\n"
+    -- message = message .. "\nPlease click the [font=default-bold][Manage mods][/font] button and disable either [font=default-bold]Krastorio 2[/font] or " .. table.concat(incompatibilities, " and ") .. "."
+
+    error(message)
+  end
+end
+
+-- if mods["space-age"] and data.raw["bool-setting"]["kr-incompatible-with-space-age"].forced_value then
+--   message = "\n[space-age] [font=default-bold]Krastorio 2[/font] is not compatible with [font=default-bold]Space Age[/font]."
+--   error("\n[space-age] [font=default-bold]Krastorio 2[/font] is not compatible with [font=default-bold]Space Age[/font].")
+-- end
+
+-- if mods["quality"] and data.raw["bool-setting"]["kr-incompatible-with-quality"].forced_value then
+--   error("Krastorio 2 is not compatible with Quality.")
+-- end

--- a/settings.lua
+++ b/settings.lua
@@ -78,4 +78,22 @@ data:extend({
     default_value = false,
     order = "c1",
   },
+  {
+    type = "bool-setting",
+    name = "kr-incompatible-with-quality",
+    setting_type = "startup",
+    default_value = true,
+    forced_value = true,
+    hidden = true,
+    order = "d1",
+  },
+  {
+    type = "bool-setting",
+    name = "kr-incompatible-with-space-age",
+    setting_type = "startup",
+    default_value = true,
+    forced_value = true,
+    hidden = true,
+    order = "d2",
+  },
 })


### PR DESCRIPTION
In continuation of https://discord.com/channels/587417951335088129/587418590744018955/1343371898687455335

A potential way to block users from playing with quality and/or space age out of the box.

The code has not cleaned up yet due to still being in the brainstorming phase, but this is what one would see currently:

![Screenshot 2025-02-24 at 17 14 24](https://github.com/user-attachments/assets/5ff7ec3d-c6d0-4b11-a813-67eec69001e3)

My main concern is that once Krastorio 2 for 2.0 hits the portal that someone will inevitably make a "space age" fork of it and reap all the downloads, it would be better if a third party compatibility mod could just hook into the main mod.

The current concept would be that the/a compatibility mod does this in their `settings-updates.lua`:
```lua
data.raw["bool-setting"]["kr-incompatible-with-quality"].forced_value = false
data.raw["bool-setting"]["kr-incompatible-with-space-age"].forced_value = false
```

Ofc such a mod should make it absolutely crystal clear (e.g. each time you load the world or join a server) that any and all "krastorio 2 space age related bugs and suggestions" should go to the compatibility mod and not krastorio 2 itself directly.

The check/message might be simplified by not checking for quality and space age directly by possibly grouping them together or something, but its all very much still up in the air and up for debate, hence this being marked as a wip.

Quality would merely dwarf the crafting speeds of the advanced machines or make them silly fast, but not inherently break anything.

Space age on the other hand as raiguard mentioned would cause two pairs of items to share names: crusher and lithium, again they won't really break anything but it would be weird, and well there's the satellite that needs looking at.

I feel like it would be a fun journey for me (and others) to try and make it compatible over time, possibly in the far future even having it absorbed into base k2, but in order to even start dreaming there would need to be a way for users to load the mods without messing with info.json's manually or have a 1-1 copy of krastorio 2 on the portal.

So yeah i'd love to hear everyone's thoughts, it would be really nice to be able to avoid a full on k2 space age fork.

🥔 