### PR TITLE
Disable cost multiplier for electronics, laboratory and steam power

### DIFF
--- a/prototypes/technologies/basic-tech-card.lua
+++ b/prototypes/technologies/basic-tech-card.lua
@@ -85,6 +85,8 @@ data:extend({
     effects = {
       { type = "unlock-recipe", recipe = "lab" },
     },
+    -- Disable cost multiplier to avoid waiting for an unreasonable amount of time due to lab being inaccessible.
+    ignore_tech_cost_multiplier = true,
   },
   {
     type = "technology",

--- a/prototypes/updates/base/technologies.lua
+++ b/prototypes/updates/base/technologies.lua
@@ -107,6 +107,8 @@ data_util.remove_recipe_unlock("military-3", "slowdown-capsule")
 data_util.remove_recipe_unlock("oil-processing", "chemical-plant")
 
 data.raw.technology["electronics"].research_trigger = nil
+-- Disable cost multiplier to avoid manually crafting unreasonable amount of basic tech cards due to assembly machines not being available.
+data.raw.technology["electronics"].ignore_tech_cost_multiplier = true
 data.raw.technology["electronics"].unit = {
   time = 10,
   count = 10,

--- a/prototypes/updates/base/technologies.lua
+++ b/prototypes/updates/base/technologies.lua
@@ -118,6 +118,8 @@ data.raw.technology["electronics"].unit = {
 }
 
 data.raw.technology["steam-power"].research_trigger = nil
+-- Disable cost multiplier to avoid manually crafting unreasonable amount of wind turbines.
+data.raw.technology["steam-power"].ignore_tech_cost_multiplier = true
 data.raw.technology["steam-power"].unit = {
   time = 10,
   count = 10,


### PR DESCRIPTION
Disable cost multiplier for electronics, laboratory and steam power so high science multiplier game takes about the same effort to start as vanilla.