### PR TITLE
Fix squeak-through compatibility errors

### DIFF
--- a/prototypes/compatibility/squeak-through-2.lua
+++ b/prototypes/compatibility/squeak-through-2.lua
@@ -12,13 +12,14 @@ data.raw["ammo-turret"]["kr-rocket-turret"].squeak_behavior = false
 
 data.raw["assembling-machine"]["kr-advanced-chemical-plant"].squeak_behavior = false
 data.raw["assembling-machine"]["kr-advanced-furnace"].squeak_behavior = false
-data.raw["assembling-machine"]["kr-air-filter"].squeak_behavior = false
+-- data.raw["assembling-machine"]["kr-air-filter"].squeak_behavior = false
 data.raw["assembling-machine"]["kr-atmospheric-condenser"].squeak_behavior = false
 data.raw["assembling-machine"]["kr-bio-lab"].squeak_behavior = false
 data.raw["assembling-machine"]["kr-electrolysis-plant"].squeak_behavior = false
 data.raw["assembling-machine"]["kr-filtration-plant"].squeak_behavior = false
 data.raw["assembling-machine"]["kr-fuel-refinery"].squeak_behavior = false
 data.raw["assembling-machine"]["kr-fuel-refinery"].squeak_behavior = false
+data.raw["assembling-machine"]["kr-fusion-reactor"].squeak_behavior = false
 data.raw["assembling-machine"]["kr-greenhouse"].squeak_behavior = false
 data.raw["assembling-machine"]["kr-matter-associator"].squeak_behavior = false
 data.raw["assembling-machine"]["kr-matter-plant"].squeak_behavior = false
@@ -42,30 +43,29 @@ data.raw["furnace"]["kr-air-purifier"].squeak_behavior = false
 data.raw["furnace"]["kr-crusher"].squeak_behavior = false
 data.raw["furnace"]["kr-crusher"].squeak_behavior = false
 data.raw["furnace"]["kr-flare-stack"].squeak_behavior = false
-data.raw["furnace"]["kr-fusion-reactor"].squeak_behavior = false
 data.raw["furnace"]["kr-stabilizer-charging-station"].squeak_behavior = false
 
 data.raw["generator"]["kr-advanced-steam-turbine"].squeak_behavior = false
 data.raw["generator"]["kr-gas-power-station"].squeak_behavior = false
 
-data.raw["lab"]["biusart_lab"].squeak_behavior = false
+-- data.raw["lab"]["biusart_lab"].squeak_behavior = false
 data.raw["lab"]["kr-singularity-lab"].squeak_behavior = false
 
 data.raw["loader-1x1"]["kr-express-loader"].squeak_behavior = false
 data.raw["loader-1x1"]["kr-fast-loader"].squeak_behavior = false
 data.raw["loader-1x1"]["kr-loader"].squeak_behavior = false
-data.raw["loader-1x1"]["kr-se-loader"].squeak_behavior = false
+-- data.raw["loader-1x1"]["kr-se-loader"].squeak_behavior = false
 data.raw["loader-1x1"]["kr-superior-loader"].squeak_behavior = false
 
-data.raw["logistic-container"]["kr-active-provider-strongbox"].squeak_behavior = false
+data.raw["container"]["kr-active-provider-strongbox"].squeak_behavior = false
 data.raw["logistic-container"]["kr-active-provider-warehouse"].squeak_behavior = false
-data.raw["logistic-container"]["kr-buffer-strongbox"].squeak_behavior = false
+data.raw["container"]["kr-buffer-strongbox"].squeak_behavior = false
 data.raw["logistic-container"]["kr-buffer-warehouse"].squeak_behavior = false
-data.raw["logistic-container"]["kr-passive-provider-strongbox"].squeak_behavior = false
+data.raw["container"]["kr-passive-provider-strongbox"].squeak_behavior = false
 data.raw["logistic-container"]["kr-passive-provider-warehouse"].squeak_behavior = false
-data.raw["logistic-container"]["kr-requester-strongbox"].squeak_behavior = false
+data.raw["container"]["kr-requester-strongbox"].squeak_behavior = false
 data.raw["logistic-container"]["kr-requester-warehouse"].squeak_behavior = false
-data.raw["logistic-container"]["kr-storage-strongbox"].squeak_behavior = false
+data.raw["container"]["kr-storage-strongbox"].squeak_behavior = false
 data.raw["logistic-container"]["kr-storage-warehouse"].squeak_behavior = false
 
 data.raw["mining-drill"]["kr-mineral-water-pumpjack"].squeak_behavior = false
@@ -83,5 +83,5 @@ data.raw["simple-entity"]["kr-planetary-teleporter-front-layer"].squeak_behavior
 
 data.raw["solar-panel"]["kr-advanced-solar-panel"].squeak_behavior = false
 
-data.raw["storage-tank"]["big-storage-tank"].squeak_behavior = false
-data.raw["storage-tank"]["huge-storage-tank"].squeak_behavior = false
+data.raw["storage-tank"]["kr-big-storage-tank"].squeak_behavior = false
+data.raw["storage-tank"]["kr-huge-storage-tank"].squeak_behavior = false


### PR DESCRIPTION
Some of the entities listed in squeak-through-2 compatibility code were listed in the wrong categories or in some cases dont exist at all.

This was just a hack to get the mods to play nice with each other.  I'm not sure this is completely correct.